### PR TITLE
redirect questions to discussions tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 ## INSPIRE helpdesk 
 This space is used for discussions and announcements on general INSPIRE topics. Before reporting a problem or asking a question here, please make sure that the problem or question is not relevant to (only) a specific INSPIRE component. If this is the case, please use the dedicated helpdesks for the [Validator](https://github.com/INSPIRE-MIF/helpdesk-validator "Validator"), [Geoportal](https://github.com/INSPIRE-MIF/helpdesk-geoportal "Geoportal") or [Registry](https://github.com/INSPIRE-MIF/helpdesk-registry "Registry").
 
-Use this issue tracker (helpdesk) to:
+Use the *Discussions tab* to [start a discussion or raise a question](https://github.com/INSPIRE-MIF/helpdesk/discussions/) related to a generic INSPIRE matter, or use the *issue tracker* to [report a generic problem](https://github.com/INSPIRE-MIF/helpdesk/issues/new?assignees=&labels=&template=report-a-problem-or-bug.md&title= "report a generic problem") related to INSPIRE.
 
-- [report a generic problem](https://github.com/INSPIRE-MIF/helpdesk/issues/new?assignees=&labels=&template=report-a-problem-or-bug.md&title= "report a generic problem") related to INSPIRE, or
-- [start a discussion or raise a question](https://github.com/INSPIRE-MIF/helpdesk/issues/new?assignees=&labels=&template=start-a-discussion.md&title= "start a discussion or raise a question") related to a generic INSPIRE matter.
+Be aware that the "New discussion" button is available only to logged users.
 
 Please follow our [Code of Conduct](code-of-conduct.md) anytime when you interact with the INSPIRE community in this space.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## INSPIRE helpdesk 
 This space is used for discussions and announcements on general INSPIRE topics. Before reporting a problem or asking a question here, please make sure that the problem or question is not relevant to (only) a specific INSPIRE component. If this is the case, please use the dedicated helpdesks for the [Validator](https://github.com/INSPIRE-MIF/helpdesk-validator "Validator"), [Geoportal](https://github.com/INSPIRE-MIF/helpdesk-geoportal "Geoportal") or [Registry](https://github.com/INSPIRE-MIF/helpdesk-registry "Registry").
 
-Use the *Discussions tab* to [start a discussion or raise a question](https://github.com/INSPIRE-MIF/helpdesk/discussions/) related to a generic INSPIRE matter, or use the *issue tracker* to [report a generic problem](https://github.com/INSPIRE-MIF/helpdesk/issues/new?assignees=&labels=&template=report-a-problem-or-bug.md&title= "report a generic problem") related to INSPIRE.
+Use the *Discussions tab* to [start a discussion or raise a question](https://github.com/INSPIRE-MIF/helpdesk/discussions/) for the helpdesk or the INSPIRE community related to a generic INSPIRE matter, or use the *issue tracker* to [report a generic problem](https://github.com/INSPIRE-MIF/helpdesk/issues/new?assignees=&labels=&template=report-a-problem-or-bug.md&title= "report a generic problem") related to INSPIRE that the helpdesk team should solve or assign to the relevant people.
 
 Be aware that the "New discussion" button is available only to logged users.
 


### PR DESCRIPTION
discussions and questions now point to GitHub discussions. While 'New issue' button is visible to non logged users, the 'New discussion' button is not, so the need to add the warning in the text